### PR TITLE
Adjusted cosine overlap threshold function

### DIFF
--- a/similarity.go
+++ b/similarity.go
@@ -76,7 +76,7 @@ func jaccardOverlapThresholdFunc(x int, t float64) int {
 var jaccardOverlapIndexThresholdFunc = jaccardOverlapThresholdFunc
 
 func cosineOverlapThresholdFunc(x int, t float64) int {
-	return int(math.Sqrt(float64(x)) * t)
+	return int(math.Ceil(math.Sqrt(float64(x)) * t))
 }
 
 var cosineOverlapIndexThresholdFunc = cosineOverlapThresholdFunc


### PR DESCRIPTION
Hello and thanks for this library!

I tried to use cosine similarity function and immediately ran into errors like these coming from allpairs.go:67:
```
panic: runtime error: slice bounds out of range [:N+1] with capacity N
```
I guess this went unnoticed because everyone else uses either Jaccard similarity or the Python version, where expression `array[:n]` is interpreted as `array[:min(len(array), n)]` so it works as intended.